### PR TITLE
use separate rabbitmq::ssl_management_port

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -5,6 +5,7 @@ rabbitmq::ssl_cacert: '/etc/ssl/sensu/cacert.pem'
 rabbitmq::ssl_cert: '/etc/ssl/sensu/server/cert.pem'
 rabbitmq::ssl_key: '/etc/ssl/sensu/server/key.pem'
 rabbitmq::ssl_port: '5671'
+rabbitmq::ssl_management_port: '15671'
 rabbitmq::sensu_user: 'sensu'
 
 # you should at least change that

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -16,7 +16,7 @@ class { '::rabbitmq':
   ssl_cacert               => hiera('rabbitmq::ssl_cacert','/etc/ssl/sensu/cacert.pem'),
   ssl_cert                 => hiera('rabbitmq::ssl_cert','/etc/ssl/sensu/server/cert.pem'),
   ssl_key                  => hiera('rabbitmq::ssl_key','/etc/ssl/sensu/server/key.pem'),
-  ssl_management_port      => hiera('rabbitmq::ssl_port','5671'),
+  ssl_management_port      => hiera('rabbitmq::ssl_management_port','15671'),
   ssl_verify               => 'verify_peer',
   ssl_fail_if_no_peer_cert => true,
 }


### PR DESCRIPTION
this fixes an eaddrinuse error on rabbitmq startup, prerequisite for
puppet to succeed installing everything.
