### PR TITLE
Fix rabbitmq vhost

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -9,7 +9,7 @@ rabbitmq::sensu_user: 'sensu'
 
 # you should at least change that
 rabbitmq::sensu_pass: 'mypass'
-rabbitmq::sensu_vhost: '/sensu'
+rabbitmq::sensu_vhost: 'sensu'
 rabbitmq::sensu_user_permissions: '%{hiera("rabbitmq::sensu_user")}@%{hiera("rabbitmq::sensu_vhost")}'
 
 ### sensu specific settings

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -6,7 +6,7 @@
 # get hiera variables for title resource
 
 $rabbitmq_sensu_user = hiera('rabbitmq::sensu_user','sensu')
-$rabbitmq_sensu_vhost = hiera('rabbitmq::sensu_vhost','/sensu')
+$rabbitmq_sensu_vhost = hiera('rabbitmq::sensu_vhost','sensu')
 $rabbitmq_sensu_permissions = hiera('rabbitmq::sensu_user_permissions','sensu@/sensu')
 
 class { '::rabbitmq':


### PR DESCRIPTION
Somehow the leading slash for sensu vhost doesn't work (sensu always tries to connect using vhost 'sensu' but rabbitmq expects '/sensu').
If the rabbitmq vhost ist created without the leading slash, sensu can successfully connect.
