### PR TITLE
Rk puppet module fix

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -43,7 +43,7 @@ sed -i '/^templatedir/d' /etc/puppet/puppet.conf
 
 # generate sensu SSL certificates to the puppet manifest can use them
 cd /root
-wget https://github.com/sensu/sensu-docs/raw/master/legacy/0.20/tools/ssl_certs.tar
+wget https://sensuapp.org/docs/latest/tools/ssl_certs.tar
 tar -xvf ssl_certs.tar
 cd ssl_certs
 ./ssl_certs.sh generate

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -23,12 +23,12 @@ LIBRARIAN_FILE=$( cat << EOF
 forge "http://forge.puppetlabs.com"
 
 mod "arioch/redis", "1.1.3"
-mod "sensu/sensu", "2.0.0"
+mod "sensu/sensu", "2.2.0"
 mod "puppetlabs/stdlib"
 mod "puppetlabs/apt"
 mod "maestrodev/wget"
 mod "garethr/erlang", "0.3.0"
-mod "puppetlabs/rabbitmq", "5.3.1"
+mod "puppetlabs/rabbitmq", "5.6.0"
 mod "nanliu/staging"
 mod "yelp/uchiwa", "0.3.0"
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -43,7 +43,7 @@ sed -i '/^templatedir/d' /etc/puppet/puppet.conf
 
 # generate sensu SSL certificates to the puppet manifest can use them
 cd /root
-wget http://sensuapp.org/docs/0.20/tools/ssl_certs.tar
+wget https://github.com/sensu/sensu-docs/raw/master/legacy/0.20/tools/ssl_certs.tar
 tar -xvf ssl_certs.tar
 cd ssl_certs
 ./ssl_certs.sh generate


### PR DESCRIPTION
Updates some of the puppet modules to the latest versions. This is now working as of March 2017. This includes the fixes in #8, which I'll now close.